### PR TITLE
[WFLY-13335] Resolve test issues when testing ee-concurrency layer

### DIFF
--- a/testsuite/integration/basic/pom.xml
+++ b/testsuite/integration/basic/pom.xml
@@ -1796,6 +1796,25 @@
                             </execution>
                             <!-- Copy users and roles config from shared resources. -->
                             <execution>
+                                <id>ee-concurrency.ts.config-as.copy-mgmt-users</id>
+                                <phase>generate-test-resources</phase>
+                                <goals>
+                                    <goal>copy-resources</goal>
+                                </goals>
+                                <inherited>true</inherited>
+                                <configuration>
+                                    <outputDirectory>${basedir}/target/wildfly-ee-concurrency/standalone/configuration</outputDirectory>
+                                    <overwrite>true</overwrite>
+                                    <resources>
+                                        <resource>
+                                            <directory>../../shared/src/main/resources</directory>
+                                            <includes><include>*.properties</include></includes>
+                                        </resource>
+                                    </resources>
+                                </configuration>
+                            </execution>
+                            <!-- Copy users and roles config from shared resources. -->
+                            <execution>
                                 <id>ejb-lite.ts.config-as.copy-mgmt-users</id>
                                 <phase>generate-test-resources</phase>
                                 <goals>
@@ -2216,6 +2235,7 @@
                                                 <layer>core-server</layer>
                                                 <layer>ejb-lite</layer>
                                                 <layer>ee-concurrency</layer>
+                                                <!-- TODO stop using unnecessarily using wars for test apps and drop this -->
                                                 <layer>servlet</layer>
                                             </layers>
                                         </config>

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ee/concurrent/DefaultContextServiceTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ee/concurrent/DefaultContextServiceTestCase.java
@@ -46,7 +46,7 @@ import org.wildfly.security.permission.ElytronPermission;
 public class DefaultContextServiceTestCase {
 
     @Deployment
-    public static WebArchive getDeployment() {
+    public static WebArchive getDeployment() { // TODO why a war for a pure EJB app?
         return ShrinkWrap.create(WebArchive.class, DefaultContextServiceTestCase.class.getSimpleName() + ".war")
                 .addClasses(DefaultContextServiceTestCase.class, DefaultContextServiceTestEJB.class, TestEJBRunnable.class, Util.class)
                 .addAsManifestResource(createPermissionsXmlAsset(

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ee/concurrent/DefaultManagedExecutorServiceTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ee/concurrent/DefaultManagedExecutorServiceTestCase.java
@@ -45,7 +45,7 @@ import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.
 public class DefaultManagedExecutorServiceTestCase {
 
     @Deployment
-    public static WebArchive getDeployment() {
+    public static WebArchive getDeployment() { // TODO why a war for a pure EJB app?
         return ShrinkWrap.create(WebArchive.class, DefaultManagedExecutorServiceTestCase.class.getSimpleName() + ".war")
                 .addClasses(DefaultManagedExecutorServiceTestCase.class, DefaultManagedExecutorServiceTestEJB.class, TestEJBRunnable.class, Util.class)
                 .addAsManifestResource(createPermissionsXmlAsset(new ElytronPermission("getSecurityDomain"),

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ee/concurrent/DefaultManagedScheduledExecutorServiceTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ee/concurrent/DefaultManagedScheduledExecutorServiceTestCase.java
@@ -46,7 +46,7 @@ import org.wildfly.security.permission.ElytronPermission;
 public class DefaultManagedScheduledExecutorServiceTestCase {
 
     @Deployment
-    public static WebArchive getDeployment() {
+    public static WebArchive getDeployment() {  // TODO why a war for a pure EJB app?
         return ShrinkWrap.create(WebArchive.class, DefaultManagedScheduledExecutorServiceTestCase.class.getSimpleName() + ".war")
                 .addClasses(DefaultManagedScheduledExecutorServiceTestCase.class, DefaultManagedScheduledExecutorServiceTestEJB.class, TestEJBRunnable.class, Util.class)
                 .addAsManifestResource(createPermissionsXmlAsset(new ElytronPermission("getSecurityDomain"),

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ee/concurrent/DefaultManagedThreadFactoryTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ee/concurrent/DefaultManagedThreadFactoryTestCase.java
@@ -48,7 +48,7 @@ import org.wildfly.security.permission.ElytronPermission;
 public class DefaultManagedThreadFactoryTestCase {
 
     @Deployment
-    public static WebArchive getDeployment() {
+    public static WebArchive getDeployment() {  // TODO why a war for a pure EJB app?
         return ShrinkWrap.create(WebArchive.class, DefaultManagedThreadFactoryTestCase.class.getSimpleName() + ".war")
                 .addClasses(DefaultManagedThreadFactoryTestCase.class, DefaultManagedThreadFactoryTestEJB.class, TestEJBRunnable.class, Util.class, TimeoutUtil.class)
                 .addAsManifestResource(createPermissionsXmlAsset(

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ee/concurrent/ManagedScheduledExecutorExceptionTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ee/concurrent/ManagedScheduledExecutorExceptionTestCase.java
@@ -41,7 +41,7 @@ import org.junit.runner.RunWith;
 public class ManagedScheduledExecutorExceptionTestCase {
 
     @Deployment
-    public static WebArchive getDeployment() {
+    public static WebArchive getDeployment() {  // TODO why a war?
         return ShrinkWrap.create(WebArchive.class, ManagedScheduledExecutorExceptionTestCase.class.getSimpleName() + ".war")
                 .addClasses(ManagedScheduledExecutorExceptionTestCase.class);
     }


### PR DESCRIPTION
Incorporate the test user/roles properties files in the provisioned wildfly-ee-concurrency installation so authentication tests can pass